### PR TITLE
Add speaker-based RAG example using Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Dirzas
+
+This repository contains a minimal example of a retrieval-augmented generation (RAG) script that groups text by speaker and queries a local Ollama language model (e.g. `phi4`).
+
+## Usage
+
+1. Place `.txt` or `.docx` files in your own directory (e.g. `docs/`). Each line should begin with the speaker name followed by a colon, for example:
+```
+Alice: Sveikas, tai yra tekstinis dokumentas.
+Bob: Sveikas, aš Bobas.
+```
+2. Run the script:
+```
+python src/rag_speaker.py docs --speaker Alice --query "Kaip sekasi?"
+```
+3. Add `--dry-run` to show retrieved context without contacting the Ollama server.
+
+Ensure that an [Ollama](https://ollama.com/) server is running locally and the `phi4` model is available if you want to generate answers.
+
+> **Note:** Sample documents are not included in this repository.

--- a/src/rag_speaker.py
+++ b/src/rag_speaker.py
@@ -1,0 +1,129 @@
+import argparse
+import json
+import os
+import re
+import zipfile
+from collections import Counter
+from math import sqrt
+from typing import Dict, List
+from urllib.request import Request, urlopen
+
+import xml.etree.ElementTree as ET
+
+
+def load_text(path: str) -> str:
+    """Load text content from a .txt or .docx file using only stdlib."""
+    if path.endswith('.txt'):
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read()
+    if path.endswith('.docx'):
+        with zipfile.ZipFile(path) as z:
+            xml_content = z.read('word/document.xml')
+        tree = ET.fromstring(xml_content)
+        texts = [
+            node.text
+            for node in tree.iter('{http://schemas.openxmlformats.org/wordprocessingml/2006/main}t')
+            if node.text
+        ]
+        return '\n'.join(texts)
+    raise ValueError(f"Unsupported file type: {path}")
+
+
+def tokenize(text: str) -> List[str]:
+    return re.findall(r"\w+", text.lower())
+
+
+def cosine_similarity(a: Counter, b: Counter) -> float:
+    common = set(a) & set(b)
+    dot = sum(a[x] * b[x] for x in common)
+    norm_a = sqrt(sum(v * v for v in a.values()))
+    norm_b = sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def parse_speakers(text: str) -> Dict[str, List[str]]:
+    pattern = re.compile(r"^([A-Za-z0-9_]+):\s*(.*)$")
+    speakers: Dict[str, List[str]] = {}
+    current = None
+    for line in text.splitlines():
+        match = pattern.match(line)
+        if match:
+            current = match.group(1)
+            speakers.setdefault(current, []).append(match.group(2))
+        else:
+            if current:
+                speakers[current][-1] += ' ' + line.strip()
+    return speakers
+
+
+class SpeakerRAG:
+    def __init__(self):
+        self.corpora: Dict[str, List[str]] = {}
+        self.tokens: Dict[str, List[Counter]] = {}
+
+    def add_speaker(self, speaker: str, texts: List[str]) -> None:
+        self.corpora[speaker] = texts
+        self.tokens[speaker] = [Counter(tokenize(t)) for t in texts]
+
+    def retrieve(self, speaker: str, query: str, top_k: int = 3) -> List[str]:
+        q_tokens = Counter(tokenize(query))
+        scores = [cosine_similarity(q_tokens, t) for t in self.tokens[speaker]]
+        ranked = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+        return [self.corpora[speaker][i] for i in ranked[:top_k]]
+
+
+def call_ollama(model: str, prompt: str) -> str:
+    try:
+        data = json.dumps({'model': model, 'prompt': prompt}).encode('utf-8')
+        req = Request(
+            'http://localhost:11434/api/generate',
+            data=data,
+            headers={'Content-Type': 'application/json'},
+        )
+        with urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode('utf-8'))
+        return result.get('response', '')
+    except Exception as exc:
+        return f"[Ollama error: {exc}]"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Speaker-based RAG using Ollama')
+    parser.add_argument('docs', help='Directory with documents')
+    parser.add_argument('--speaker', required=True, help='Speaker to query')
+    parser.add_argument('--query', required=True, help='Question to ask')
+    parser.add_argument('--model', default='phi4', help='Ollama model name')
+    parser.add_argument('--top-k', type=int, default=3, help='Number of context chunks')
+    parser.add_argument('--dry-run', action='store_true', help='Do not call LLM')
+    args = parser.parse_args()
+
+    rag = SpeakerRAG()
+    all_speakers: Dict[str, List[str]] = {}
+
+    for fname in os.listdir(args.docs):
+        if not (fname.endswith('.txt') or fname.endswith('.docx')):
+            continue
+        text = load_text(os.path.join(args.docs, fname))
+        parsed = parse_speakers(text)
+        for sp, segs in parsed.items():
+            all_speakers.setdefault(sp, []).extend(segs)
+
+    for sp, segs in all_speakers.items():
+        rag.add_speaker(sp, segs)
+
+    if args.speaker not in rag.corpora:
+        raise ValueError(f"Speaker '{args.speaker}' not found")
+
+    segments = rag.retrieve(args.speaker, args.query, args.top_k)
+    prompt = '\n\n'.join(segments) + f"\n\nQuestion: {args.query}"
+
+    if args.dry_run:
+        print('Retrieved context:\n' + prompt)
+    else:
+        print(call_ollama(args.model, prompt))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python script for speaker-based retrieval-augmented generation
- include usage instructions (no sample documents in repo)
- remove sample documents that triggered GitHub binary-file warning

## Testing
- `python src/rag_speaker.py test_docs --speaker Alice --query "Kaip sekasi?" --dry-run`


------
https://chatgpt.com/codex/tasks/task_b_68ba7d16ffb883298dad3aac6f1a2d54