### PR TITLE
Improve speaker parsing for RAG script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This repository contains a minimal example of a retrieval-augmented generation (
 
 ## Usage
 
-1. Place `.txt` or `.docx` files in your own directory (e.g. `docs/`). Each line should begin with the speaker name followed by a colon, for example:
+1. Place `.txt` or `.docx` files in your own directory (e.g. `docs/`). Each line should begin with the speaker name followed by a colon or a period, for example:
 ```
 Alice: Sveikas, tai yra tekstinis dokumentas.
 Bob: Sveikas, aš Bobas.
+PIRMININKAS (S. SKVERNELIS). Labas rytas.
 ```
 2. Run the script:
 ```


### PR DESCRIPTION
## Summary
- Allow `rag_speaker.py` to parse speaker names ending with a period and containing spaces or parentheses
- Document period-delimited speaker lines in README

## Testing
- `python -m py_compile src/rag_speaker.py`


------
https://chatgpt.com/codex/tasks/task_b_68ba7f54e64c8329818b69fe11805b87