### PR TITLE
Add basic Gradio web UI and configurable Ollama endpoint

### DIFF
--- a/src/rag_speaker.py
+++ b/src/rag_speaker.py
@@ -93,11 +93,11 @@ class SpeakerRAG:
         return [self.corpora[speaker][i] for i in ranked[:top_k]]
 
 
-def call_ollama(model: str, prompt: str) -> str:
+def call_ollama(model: str, prompt: str, url: str = 'http://localhost:11434/api/generate') -> str:
     try:
         data = json.dumps({'model': model, 'prompt': prompt}).encode('utf-8')
         req = Request(
-            'http://localhost:11434/api/generate',
+            url,
             data=data,
             headers={'Content-Type': 'application/json'},
         )

--- a/src/web_ui.py
+++ b/src/web_ui.py
@@ -1,0 +1,67 @@
+from typing import List, Tuple
+
+import gradio as gr
+
+from rag_speaker import SpeakerRAG, load_text, parse_speakers, call_ollama
+
+rag = SpeakerRAG()
+ollama_url = 'http://localhost:11434/api/generate'
+model_name = 'phi4'
+
+def chat_fn(history: List[Tuple[str, str]], question: str, speaker: str):
+    if not speaker:
+        history.append((question, 'Please select a speaker'))
+        return history, ''
+    if speaker not in rag.corpora:
+        history.append((question, f"Speaker '{speaker}' not found"))
+        return history, ''
+    segments = rag.retrieve(speaker, question)
+    prompt = '\n\n'.join(segments) + f"\n\nQuestion: {question}"
+    answer = call_ollama(model=model_name, prompt=prompt, url=ollama_url)
+    history.append((question, answer))
+    return history, ''
+
+def upload_fn(files: List[gr.File]) -> Tuple[gr.Dropdown, str]:
+    for file in files:
+        text = load_text(file.name)
+        parsed = parse_speakers(text)
+        for sp, segs in parsed.items():
+            existing = rag.corpora.get(sp, [])
+            rag.add_speaker(sp, existing + segs)
+    speakers = list(rag.corpora.keys())
+    return gr.Dropdown.update(choices=speakers), ', '.join(speakers)
+
+def clear_db() -> Tuple[gr.Dropdown, str]:
+    rag.corpora.clear()
+    rag.tokens.clear()
+    return gr.Dropdown.update(choices=[]), 'Database cleared'
+
+def save_settings(url: str, model: str) -> str:
+    global ollama_url, model_name
+    ollama_url = url
+    model_name = model
+    return 'Settings saved'
+
+with gr.Blocks() as demo:
+    gr.Markdown('# RAG Web UI')
+    with gr.Tab('Chat'):
+        speaker_dd = gr.Dropdown(label='Speaker', choices=[])
+        chatbot = gr.Chatbot(height=400)
+        msg = gr.Textbox(label='Your question')
+        msg.submit(chat_fn, [chatbot, msg, speaker_dd], [chatbot, msg])
+    with gr.Tab('Documents'):
+        file_input = gr.File(file_types=['text', 'docx'], file_count='multiple', label='Upload documents')
+        upload_btn = gr.Button('Add to database')
+        speakers_box = gr.Textbox(label='Known speakers', interactive=False)
+        upload_btn.click(upload_fn, [file_input], [speaker_dd, speakers_box])
+    with gr.Tab('Settings'):
+        url_box = gr.Textbox(label='Ollama URL', value=ollama_url)
+        model_box = gr.Textbox(label='LLM Model', value=model_name)
+        clear_btn = gr.Button('Clear database')
+        save_btn = gr.Button('Save settings')
+        status = gr.Textbox(label='Status', interactive=False)
+        clear_btn.click(lambda: clear_db(), [], [speaker_dd, status])
+        save_btn.click(save_settings, [url_box, model_box], [status])
+
+if __name__ == '__main__':
+    demo.launch()


### PR DESCRIPTION
## Summary
- Introduce a Gradio-based web interface with Chat, Documents, and Settings tabs
- Allow dynamic Ollama URL and model selection along with RAG database management
- Parameterize `call_ollama` function for flexible endpoint usage

## Testing
- `python -m py_compile src/*.py`
- `python -c "import gradio"` *(fails: ModuleNotFoundError: No module named 'gradio')*
- `pip install gradio` *(fails: Could not find a version that satisfies the requirement gradio)*

------
https://chatgpt.com/codex/tasks/task_b_68ba80c6b6f883298f944f9d85c4241e