### PR TITLE
Print raw Ollama JSON responses to console

### DIFF
--- a/src/rag_speaker.py
+++ b/src/rag_speaker.py
@@ -107,7 +107,9 @@ def call_ollama(model: str, prompt: str, url: str = 'http://localhost:11434/api/
             headers={'Content-Type': 'application/json'},
         )
         with urlopen(req, timeout=30) as resp:
-            result = json.loads(resp.read().decode('utf-8'))
+            raw = resp.read().decode('utf-8')
+        print(raw)
+        result = json.loads(raw)
         return result.get('response', '')
     except Exception as exc:
         return f"[Ollama error: {exc}]"


### PR DESCRIPTION
## Summary
- Print Ollama's raw JSON response before decoding to help debug malformed payloads

## Testing
- `python -m py_compile src/rag_speaker.py src/web_ui.py`
- `python src/rag_speaker.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68ba8925190c832996f6af2dafd770d1