### PR TITLE
Ensure speaker filtering for context retrieval

### DIFF
--- a/src/rag_speaker.py
+++ b/src/rag_speaker.py
@@ -47,11 +47,11 @@ def cosine_similarity(a: Counter, b: Counter) -> float:
 def parse_speakers(text: str) -> Dict[str, List[str]]:
     """Split transcript text into segments grouped by speaker.
 
-    The function recognises lines where a speaker name (all caps) is
-    followed by either a colon or a period, for example::
+    The function recognises lines where a speaker name is followed by
+    either a colon or a period, for example::
 
-        PIRMININKAS: Sveiki.
-        V. ALEKNAVIČIENĖ (LSDPF*). Labas.
+        Alice: Sveiki.
+        PIRMININKAS (S. SKVERNELIS). Labas.
 
     ``parse_speakers`` is careful not to split inside initials such as
     ``V. ALEKNAVIČIENĖ`` by selecting the first ``:`` or ``.`` whose
@@ -68,7 +68,13 @@ def parse_speakers(text: str) -> Dict[str, List[str]]:
         for match in re.finditer(r"[\.:]", line):
             speaker = line[:match.start()].strip()
             remainder = line[match.end():].strip()
-            if speaker and speaker.isupper() and not speaker[0].isdigit():
+            # ``parse_speakers`` previously required the speaker label to be in
+            # all caps, which caused the entire transcript to be assigned to the
+            # first uppercase speaker whenever names appeared in mixed or
+            # lowercase.  This resulted in queries retrieving context from every
+            # speaker instead of just the selected one.  Accept any name that
+            # starts with a non-digit character instead.
+            if speaker and not speaker[0].isdigit():
                 words = remainder.split()
                 if words and words[0].isupper():
                     # Likely an initial, keep searching


### PR DESCRIPTION
## Summary
- Allow `parse_speakers` to recognise speaker labels in any case so only the chosen speaker's lines are retrieved.
- Document the broader speaker name matching and explain previous issue.

## Testing
- `python -m py_compile src/rag_speaker.py src/web_ui.py`
- `python - <<'PY'
import sys; sys.path.append('src')
from rag_speaker import parse_speakers, SpeakerRAG
text = "Alice: Hello.\nBob: Hi there.\nAlice: Another line.\nBob: Last line from Bob."
parsed = parse_speakers(text)
print('parsed:', parsed)
rag = SpeakerRAG()
for sp, segs in parsed.items():
    rag.add_speaker(sp, segs)
print('RAG corpora', rag.corpora)
print('Retrieve for Alice', rag.retrieve('Alice', 'hello'))
print('Retrieve for Bob', rag.retrieve('Bob', 'line'))
PY`

------
https://chatgpt.com/codex/tasks/task_b_68ba8d98db4083299953556342baa926