### PR TITLE
Revert speaker parsing changes from PRs #12 and #11

### DIFF
--- a/src/rag_speaker.py
+++ b/src/rag_speaker.py
@@ -47,11 +47,11 @@ def cosine_similarity(a: Counter, b: Counter) -> float:
 def parse_speakers(text: str) -> Dict[str, List[str]]:
     """Split transcript text into segments grouped by speaker.
 
-    The function recognises lines where a speaker name is followed by
-    either a colon or a period, for example::
+    The function recognises lines where a speaker name (all caps) is
+    followed by either a colon or a period, for example::
 
-        Alice: Sveiki.
-        PIRMININKAS (S. SKVERNELIS). Labas.
+        PIRMININKAS: Sveiki.
+        V. ALEKNAVIČIENĖ (LSDPF*). Labas.
 
     ``parse_speakers`` is careful not to split inside initials such as
     ``V. ALEKNAVIČIENĖ`` by selecting the first ``:`` or ``.`` whose
@@ -68,15 +68,7 @@ def parse_speakers(text: str) -> Dict[str, List[str]]:
         for match in re.finditer(r"[\.:]", line):
             speaker = line[:match.start()].strip()
             remainder = line[match.end():].strip()
-            # ``parse_speakers`` previously required the speaker label to be in
-            # all caps, which caused the entire transcript to be assigned to the
-            # first uppercase speaker whenever names appeared in mixed or
-            # lowercase.  This resulted in queries retrieving context from every
-            # speaker instead of just the selected one.  Accept any name that
-            # starts with a non-digit character instead, but only if there is
-            # actual text after the delimiter.  Otherwise regular sentences like
-            # ``Sveiki atvykę į posėdį.`` would be treated as speaker names.
-            if speaker and remainder and not speaker[0].isdigit():
+            if speaker and speaker.isupper() and not speaker[0].isdigit():
                 words = remainder.split()
                 if words and words[0].isupper():
                     # Likely an initial, keep searching


### PR DESCRIPTION
## Summary
- Revert merge of PR #12 to drop skipping of dialogue-free lines in `parse_speakers`
- Revert merge of PR #11 to restore original text extraction and speaker handling

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ba945eba9c83298cd72ec90bbf2a98