### PR TITLE
Add date-filtered chat for documents

### DIFF
--- a/src/web_ui.py
+++ b/src/web_ui.py
@@ -4,13 +4,22 @@ import gradio as gr
 import json
 from pathlib import Path
 
-from rag_speaker import SpeakerRAG, load_text, parse_speakers, call_ollama
+from rag_speaker import (
+    SpeakerRAG,
+    call_ollama,
+    extract_document_date,
+    load_text,
+    parse_speakers,
+)
 
 rag = SpeakerRAG()
+date_rag = SpeakerRAG()
 
 DEFAULT_URL = 'http://localhost:11434/api/generate'
 DEFAULT_MODEL = 'phi4'
 CONFIG_PATH = Path(__file__).resolve().parent.parent / 'settings.json'
+
+UNKNOWN_DATE_LABEL = 'Nežinoma data'
 
 ollama_url = DEFAULT_URL
 model_name = DEFAULT_MODEL
@@ -38,7 +47,34 @@ def chat_fn(history: List[Tuple[str, str]], question: str, speaker: str):
     history.append((question, answer))
     return history, ''
 
-def upload_fn(files: List[gr.File]) -> Tuple[gr.Dropdown, str]:
+def date_chat_fn(history: List[Tuple[str, str]], question: str, date_label: str):
+    if not date_label:
+        history.append((question, 'Please select a document date'))
+        return history, ''
+    if date_label not in date_rag.corpora:
+        history.append((question, f"Date '{date_label}' not found"))
+        return history, ''
+    segments = date_rag.retrieve(date_label, question)
+    context = '\n\n'.join(segments)
+    prompt = (
+        f"Use the following context from documents dated {date_label} to answer the question.\n\n"
+        f"Context:\n{context}\n\nQuestion: {question}\nAnswer:"
+    )
+    answer = call_ollama(model=model_name, prompt=prompt, url=ollama_url)
+    history.append((question, answer))
+    return history, ''
+
+
+def upload_fn(files: List[gr.File]) -> Tuple[gr.Dropdown, str, gr.Dropdown, str]:
+    if not files:
+        speakers = sorted(rag.corpora.keys())
+        dates = sorted(date_rag.corpora.keys())
+        return (
+            gr.Dropdown(choices=speakers),
+            ', '.join(speakers),
+            gr.Dropdown(choices=dates),
+            ', '.join(dates),
+        )
     for file in files:
         try:
             text = load_text(file.name)
@@ -46,16 +82,45 @@ def upload_fn(files: List[gr.File]) -> Tuple[gr.Dropdown, str]:
             # Skip files with unsupported extensions
             continue
         parsed = parse_speakers(text)
+        date_segments: List[str] = []
         for sp, segs in parsed.items():
             existing = rag.corpora.get(sp, [])
             rag.add_speaker(sp, existing + segs)
-    speakers = list(rag.corpora.keys())
-    return gr.Dropdown(choices=speakers), ', '.join(speakers)
+            date_segments.extend(segs)
+        if not date_segments:
+            date_segments = [
+                paragraph.strip()
+                for paragraph in text.split('\n\n')
+                if paragraph.strip()
+            ]
+        date_label = extract_document_date(text) or UNKNOWN_DATE_LABEL
+        existing_date = date_rag.corpora.get(date_label, [])
+        if date_segments:
+            date_rag.add_speaker(date_label, existing_date + date_segments)
+    speakers = sorted(rag.corpora.keys())
+    dates = sorted(date_rag.corpora.keys())
+    speakers_text = ', '.join(speakers)
+    dates_text = ', '.join(dates)
+    return (
+        gr.Dropdown(choices=speakers),
+        speakers_text,
+        gr.Dropdown(choices=dates),
+        dates_text,
+    )
 
-def clear_db() -> Tuple[gr.Dropdown, str]:
+
+def clear_db() -> Tuple[gr.Dropdown, str, gr.Dropdown, str, str]:
     rag.corpora.clear()
     rag.tokens.clear()
-    return gr.Dropdown(choices=[]), 'Database cleared'
+    date_rag.corpora.clear()
+    date_rag.tokens.clear()
+    return (
+        gr.Dropdown(choices=[]),
+        'Database cleared',
+        gr.Dropdown(choices=[]),
+        '',
+        '',
+    )
 
 def save_settings(url: str, model: str) -> str:
     global ollama_url, model_name
@@ -72,6 +137,11 @@ with gr.Blocks() as demo:
         chatbot = gr.Chatbot(height=400)
         msg = gr.Textbox(label='Your question')
         msg.submit(chat_fn, [chatbot, msg, speaker_dd], [chatbot, msg])
+    with gr.Tab('Date Chat'):
+        date_dd = gr.Dropdown(label='Document date', choices=[])
+        date_chatbot = gr.Chatbot(height=400)
+        date_msg = gr.Textbox(label='Your question')
+        date_msg.submit(date_chat_fn, [date_chatbot, date_msg, date_dd], [date_chatbot, date_msg])
     with gr.Tab('Documents'):
         # Gradio 4 does not recognise ``docx`` in ``file_types``. Allow any
         # file to be uploaded and rely on ``load_text`` to filter by
@@ -79,14 +149,19 @@ with gr.Blocks() as demo:
         file_input = gr.File(file_types=['file'], file_count='multiple', label='Upload documents')
         upload_btn = gr.Button('Add to database')
         speakers_box = gr.Textbox(label='Known speakers', interactive=False)
-        upload_btn.click(upload_fn, [file_input], [speaker_dd, speakers_box])
+        dates_box = gr.Textbox(label='Known dates', interactive=False)
+        upload_btn.click(upload_fn, [file_input], [speaker_dd, speakers_box, date_dd, dates_box])
     with gr.Tab('Settings'):
         url_box = gr.Textbox(label='Ollama URL', value=ollama_url)
         model_box = gr.Textbox(label='LLM Model', value=model_name)
         clear_btn = gr.Button('Clear database')
         save_btn = gr.Button('Save settings')
         status = gr.Textbox(label='Status', interactive=False)
-        clear_btn.click(lambda: clear_db(), [], [speaker_dd, status])
+        clear_btn.click(
+            clear_db,
+            [],
+            [speaker_dd, status, date_dd, speakers_box, dates_box],
+        )
         save_btn.click(save_settings, [url_box, model_box], [status])
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- extract document dates near the header using lightweight regex detection
- add a second Gradio chat tab that retrieves context across documents filtered by date
- track known dates alongside speakers when uploading, and clear them with the database

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68c900cf44f48329b39c36478d36ca1d