### PR TITLE
Add YouTube transcription ingestion to web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a minimal example of a retrieval-augmented generation (RAG) script that groups text by speaker and queries a local Ollama language model (e.g. `phi4`).
 
+## Web UI
+
+A simple Gradio-based interface is available via `python src/web_ui.py`. Upload `.txt` or `.docx` files in the *Documents* tab or paste a YouTube link into the *YouTube* tab. The app retrieves the transcript for the supplied video and stores it under a synthetic "YouTube ..." speaker name. If the video title contains a date (e.g. `2024-05-16` or `2024 m. gegužės 16 d.`), that date is assigned automatically so the conversation also becomes searchable from the *Date Chat* tab.
+
 ## Usage
 
 1. Place `.txt` or `.docx` files in your own directory (e.g. `docs/`). Each line should begin with the speaker name followed by a colon or a period, for example:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 gradio
+youtube-transcript-api


### PR DESCRIPTION
## Summary
- add helper utilities for extracting YouTube metadata and transcripts so videos can be ingested without speaker labels
- extend the Gradio interface with a YouTube tab that saves transcripts under synthetic speaker/date entries and updates dropdowns automatically
- document the new workflow and record the youtube-transcript-api dependency

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68c904cac544832989ad6768179d1c37