### PR TITLE
Enable calendar script in date selection tab

### DIFF
--- a/src/web_ui.py
+++ b/src/web_ui.py
@@ -796,7 +796,9 @@ with gr.Blocks() as demo:
         msg.submit(chat_fn, [chatbot, msg, speaker_dd], [chatbot, msg])
     with gr.Tab('Date Chat'):
         with gr.Row():
-            calendar_html = gr.HTML(value=_render_calendar_html([], None, None))
+            calendar_html = gr.HTML(
+                value=_render_calendar_html([], None, None), sanitize_html=False
+            )
             with gr.Column():
                 date_start_value = gr.Textbox(
                     label='Selected start date',


### PR DESCRIPTION
## Summary
- disable HTML sanitization for the date selection calendar so its inline script can render the UI

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68caa73ad4c083298abfe4c41880bf76