### PR TITLE
Allow dates without day suffix

### DIFF
--- a/src/rag_speaker.py
+++ b/src/rag_speaker.py
@@ -87,7 +87,7 @@ def parse_speakers(text: str) -> Dict[str, List[str]]:
 
 _DATE_PATTERNS = [
     re.compile(
-        r"\b\d{4}\s*m\.\s*[A-Za-zĄČĘĖĮŠŲŪŽąčęėįšųūž]+(?:\s+[A-Za-zĄČĘĖĮŠŲŪŽąčęėįšųūž]+)*\s+\d{1,2}\s*d\.?",
+        r"\b\d{4}\s*m\.\s*[A-Za-zĄČĘĖĮŠŲŪŽąčęėįšųūž]+(?:\s+[A-Za-zĄČĘĖĮŠŲŪŽąčęėįšųūž]+)*\s+\d{1,2}(?:\s*d\.?)?",
         re.IGNORECASE,
     ),
     re.compile(r"\b\d{4}[-/.]\d{1,2}[-/.]\d{1,2}\b"),

--- a/src/web_ui.py
+++ b/src/web_ui.py
@@ -93,7 +93,7 @@ def _parse_date_label(label: str) -> Optional[dt_date]:
         pass
 
     match = re.search(
-        r'(\d{4})\s*m\.\s*([A-Za-zĄČĘĖĮŠŲŪŽąčęėįšųūž\s\.]*)\s+(\d{1,2})\s*d\.?',
+        r'(\d{4})\s*m\.\s*([A-Za-zĄČĘĖĮŠŲŪŽąčęėįšųūž\s\.]*)\s+(\d{1,2})(?:\s*d\.?)?',
         cleaned,
         re.IGNORECASE,
     )


### PR DESCRIPTION
## Summary
- allow the document date extraction regex to match Lithuanian dates that omit the trailing "d"
- update the calendar date parser to understand the same format so newly ingested files surface in the date picker

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68caae00e6c083298f3ccfc63c4d535c